### PR TITLE
Fix low probability hanging in diff-tree execution

### DIFF
--- a/gerritcheck/check.py
+++ b/gerritcheck/check.py
@@ -17,6 +17,8 @@ from collections import defaultdict
 from plumbum import local, SshMachine
 from flake8.engine import get_style_guide
 
+# Subprocess is used to address https://github.com/tomerfiliba/plumbum/issues/295
+from subprocess import Popen, PIPE
 import argparse
 try:
     from exceptions import RuntimeError
@@ -44,13 +46,16 @@ def extract_files_for_commit(rev):
     """
     :return: A list of files that where modified in revision 'rev'
     """
-    result = git.popen(("diff-tree", "--no-commit-id", "--name-only", "-r", str(rev)))
-    rc  = result.wait()
-    if rc != 0:
+    diff = Popen(["git", "diff-tree", "--no-commit-id", "--name-only", "-r", str(rev)],
+            stdout=PIPE)
+
+    out, err = diff.communicate()
+
+    if err:
         raise GerritCheckExecption("Could not run diff on current revision. "
                                    "Make sure that the current revision has a "
-                                   "parent.")
-    return [f[0].strip() for f in result if len(f[0].strip())]
+                                   "parent:" + err)
+    return [f.strip() for f in out.splitlines() if len(f)]
 
 
 def filter_files(files, suffix=CPP_FILES):


### PR DESCRIPTION
Chance to see this issue in real life is quite small. Only one developer in our company was lucky enough to make change set that is able to repeat deadlock in subprocess.wait module in 100% cases.

More details in: https://github.com/tomerfiliba/plumbum/issues/295
