### PR TITLE
ssh error while resolving hostname

### DIFF
--- a/gerritcheck/check.py
+++ b/gerritcheck/check.py
@@ -190,7 +190,7 @@ def cpplint_on_files(files, commit, filters=DEFAULT_CPPLINT_FILTER_OPTIONS):
 
 def submit_review(change, user, host, data, port=22):
     """Uses the data as input to submit a new review."""
-    remote = local["ssh"]["{0}@{1}:{2}".format(user, host, port)]
+    remote = local["ssh"]["-p {0}".format(port),"{0}@{1}".format(user, host)]
     (local["cat"] << data | remote["gerrit", "review", change, "--json"])()
 
 


### PR DESCRIPTION
Pass port to ssh using -p option to avoid error " Could not resolve hostname" if the Url is not parsed correctly.