### PR TITLE
Do not call git blame for line 0.

### DIFF
--- a/gerritcheck/check.py
+++ b/gerritcheck/check.py
@@ -72,6 +72,8 @@ def filter_files(files, suffix=CPP_FILES):
 def line_part_of_commit(file, line, commit):
     """Helper function that returns true if a particular `line` in a
     particular `file` was last changed in `commit`."""
+    if line == '0': return False
+
     line_val = git("blame", "-l", "-L{0},{0}".format(line), file)
     return line_val.split(" ", 1)[0] == commit
 


### PR DESCRIPTION
Pass port to ssh using -p option to avoid error " Could not resolve hostname" if the Url is not parsed correctly.